### PR TITLE
Slightly hardier reinit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char ** argv) {
         ("no-http", "Do not listen on http", cxxopts::value<bool>()->default_value("false"))
         ("no-timeout", "Do not exit after 20 seconds of no input", cxxopts::value<bool>()->default_value("false"))
         ("no-signals", "Do not catch signals", cxxopts::value<bool>()->default_value("false"))
-        ("f,fontname", "FBInk Bitmap fontname, one of ibm, unscii, unscii_alt, unscii_thin, unscii_fantasy, unscii_mcr, unscii_tall, block, leggie, veggie, kates, fkp, ctrld, orp, orpb, orpi, scientifica, scientificab, scientificai, terminus, terminusb, fatty, spleen, tewi, tewib, topaz, microknight or vga",
+        ("f,fontname", "FBInk Bitmap fontname, one of ibm, unscii, unscii_alt, unscii_thin, unscii_fantasy, unscii_mcr, unscii_tall, block, leggie, veggie, kates, fkp, ctrld, orp, orpb, orpi, scientifica, scientificab, scientificai, terminus, terminusb, fatty, spleen, tewi, tewib, topaz, microknight, vga or cozette",
             cxxopts::value<std::string>()->default_value("terminus"))
         ("s,fontsize", "Fontsize multiplier", cxxopts::value<int>()->default_value("2"))
     ;

--- a/src/vterm.hpp
+++ b/src/vterm.hpp
@@ -87,8 +87,8 @@ public:
         // only call this from main (yeah bad code...)
         // because we need to resize the pty too
         int res = fbink_reinit(fbfd, &config);
-        if ((res == OK_BPP_CHANGE) || (res == OK_ROTA_CHANGE)) {
-            /* if both changed, OK_BPP_CHANGE `wins' */
+        if (res > EXIT_SUCCESS && res & OK_LAYOUT_CHANGE) {
+            /* we only actually care about layout changes */
             fbink_get_state(&config, &state);
             printf("fbink_reinit()\n");
             vterm_set_size(term, state.max_rows, state.max_cols);

--- a/src/vterm.hpp
+++ b/src/vterm.hpp
@@ -91,6 +91,7 @@ public:
             /* we only actually care about layout changes */
             fbink_get_state(&config, &state);
             printf("fbink_reinit()\n");
+            vterm_screen_reset(screen, 1);
             vterm_set_size(term, state.max_rows, state.max_cols);
             return true;
         }

--- a/src/vterm.hpp
+++ b/src/vterm.hpp
@@ -253,6 +253,12 @@ public:
         else if (font == "topaz") return FONT_INDEX_E::TOPAZ;
         else if (font == "microknight") return FONT_INDEX_E::MICROKNIGHT;
         else if (font == "vga") return FONT_INDEX_E::VGA;
+        /*
+        // Not compiled in by default
+        else if (font == "unifont") return FONT_INDEX_E::UNIFONT;
+        else if (font == "unifontdw") return FONT_INDEX_E::UNIFONTDW;
+        */
+        else if (font == "cozette") return FONT_INDEX_E::COZETTE;
         printf("requesting non-existing font '%s'\n", font_cstr);
         return FONT_INDEX_E::TERMINUS;
     }


### PR DESCRIPTION
Only actually resize the terminal on layout swaps (as opposed to a simple rotation inversion).
Also, reset/clear the screen first, to avoid potential crashes (possibly a race on devices where a rotation is done in two steps, because NTX kernels are fun. This at least fixed 0 <-> 2 on my H2O ;))

Update FBInk to pull a minor API change that made the return value from fbink_reinit slightly more usable ;). (i.e., if it's positive, it's a bitmask with each and every reason why the reinit was needed recorded).